### PR TITLE
feat: add standardized healthz contract

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -38,8 +38,10 @@ helm upgrade -i "${RELEASE_NAME}" -n "${NAMESPACE}" --create-namespace "${CHART_
 
 ## 健康检查
 
-Sealaf web 和 server 都暴露稳定的 `GET /healthz`。接口返回
-`{"service":"sealaf","status":"ok"}`，并设置 `Cache-Control: no-store`。
+Sealaf web 和 server 都暴露稳定的 `GET /healthz`。web 由 nginx 直接返回
+`{"service":"sealaf","status":"ok"}`，server 的 `/healthz` 会先对系统
+数据库执行一次 MongoDB ping，只有在可达时才返回 200。响应都会设置
+`Cache-Control: no-store`。
 Helm chart 使用 `/healthz` 作为 web 和 server 的 startup、liveness 和
 readiness 探针路径。
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -39,9 +39,11 @@ helm upgrade -i "${RELEASE_NAME}" -n "${NAMESPACE}" --create-namespace "${CHART_
 ## 健康检查
 
 Sealaf web 和 server 都暴露稳定的 `GET /healthz`。web 由 nginx 直接返回
-`{"service":"sealaf","status":"ok"}`，server 的 `/healthz` 会先对系统
-数据库执行一次 MongoDB ping，只有在可达时才返回 200。响应都会设置
-`Cache-Control: no-store`。
+`{"service":"sealaf","status":"ok"}`，server 的 `/healthz` 会检查必要配置
+和系统数据库连通性：`DATABASE_URL`、`JWT_SECRET`、
+`DEFAULT_REGION_RUNTIME_DOMAIN` 必须存在，`DEFAULT_REGION_TLS_ENABLED=true`
+时还要求 `DEFAULT_REGION_TLS_WILDCARD_CERTIFICATE_SECRET_NAME` 可用。响应都
+会设置 `Cache-Control: no-store`。
 Helm chart 使用 `/healthz` 作为 web 和 server 的 startup、liveness 和
 readiness 探针路径。
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -36,6 +36,13 @@ helm upgrade -i "${RELEASE_NAME}" -n "${NAMESPACE}" --create-namespace "${CHART_
 - `HELM_OPTS`: 通过 `sealos run -e HELM_OPTS=...` 传入的额外 Helm 参数。
 - `--wait`: 等待 Kubernetes 资源 ready 后再退出。
 
+## 健康检查
+
+Sealaf web 和 server 都暴露稳定的 `GET /healthz`。接口返回
+`{"service":"sealaf","status":"ok"}`，并设置 `Cache-Control: no-store`。
+Helm chart 使用 `/healthz` 作为 web 和 server 的 startup、liveness 和
+readiness 探针路径。
+
 ## 初始安装
 
 全新环境直接执行：

--- a/deploy/charts/sealaf/templates/deployment.yaml
+++ b/deploy/charts/sealaf/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.web.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.web.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -181,6 +185,10 @@ spec:
             {{- end }}
           {{- with .Values.server.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.startupProbe }}
+          startupProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.server.livenessProbe }}

--- a/deploy/charts/sealaf/values.yaml
+++ b/deploy/charts/sealaf/values.yaml
@@ -99,9 +99,18 @@ web:
     requests:
       cpu: 20m
       memory: 25Mi
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+      scheme: HTTP
+    timeoutSeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    failureThreshold: 24
   livenessProbe:
     httpGet:
-      path: /
+      path: /healthz
       port: http
       scheme: HTTP
     timeoutSeconds: 1
@@ -110,7 +119,7 @@ web:
     failureThreshold: 3
   readinessProbe:
     httpGet:
-      path: /
+      path: /healthz
       port: http
       scheme: HTTP
     timeoutSeconds: 1
@@ -144,9 +153,18 @@ server:
     requests:
       cpu: 100m
       memory: 204Mi
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+      scheme: HTTP
+    timeoutSeconds: 1
+    periodSeconds: 5
+    successThreshold: 1
+    failureThreshold: 24
   livenessProbe:
     httpGet:
-      path: /v1/regions
+      path: /healthz
       port: http
       scheme: HTTP
     timeoutSeconds: 1
@@ -155,7 +173,7 @@ server:
     failureThreshold: 3
   readinessProbe:
     httpGet:
-      path: /v1/regions
+      path: /healthz
       port: http
       scheme: HTTP
     timeoutSeconds: 1

--- a/server/src/healthz.spec.ts
+++ b/server/src/healthz.spec.ts
@@ -1,4 +1,18 @@
-import { healthzMiddleware, healthzPayload } from './healthz'
+const mockCommand = jest.fn()
+
+jest.mock('./system-database', () => ({
+  SystemDatabase: {
+    db: {
+      command: mockCommand,
+    },
+  },
+}))
+
+import {
+  healthzMiddleware,
+  healthzPayload,
+  healthzUnhealthyPayload,
+} from './healthz'
 
 function createResponse() {
   const headers = new Map<string, string>()
@@ -22,27 +36,51 @@ function createResponse() {
 }
 
 describe('healthzMiddleware', () => {
-  it('returns the standard health contract for GET /healthz', () => {
+  beforeEach(() => {
+    mockCommand.mockReset()
+  })
+
+  it('returns the standard health contract for GET /healthz', async () => {
+    mockCommand.mockResolvedValueOnce(undefined)
     const res = createResponse()
     const next = jest.fn()
 
-    healthzMiddleware(
+    await healthzMiddleware(
       { method: 'GET', path: '/healthz' } as never,
       res as never,
       next,
     )
 
     expect(next).not.toHaveBeenCalled()
+    expect(mockCommand).toHaveBeenCalledWith({ ping: 1 })
     expect(res.statusCode).toBe(200)
     expect(res.headers.get('Cache-Control')).toBe('no-store')
     expect(res.body).toEqual(healthzPayload)
   })
 
-  it('passes non-health requests to the next handler', () => {
+  it('returns an error payload when the database ping fails', async () => {
+    mockCommand.mockRejectedValueOnce(new Error('db down'))
     const res = createResponse()
     const next = jest.fn()
 
-    healthzMiddleware(
+    await healthzMiddleware(
+      { method: 'GET', path: '/healthz' } as never,
+      res as never,
+      next,
+    )
+
+    expect(next).not.toHaveBeenCalled()
+    expect(mockCommand).toHaveBeenCalledWith({ ping: 1 })
+    expect(res.statusCode).toBe(503)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    expect(res.body).toEqual(healthzUnhealthyPayload)
+  })
+
+  it('passes non-health requests to the next handler', async () => {
+    const res = createResponse()
+    const next = jest.fn()
+
+    await healthzMiddleware(
       { method: 'GET', path: '/v1/regions' } as never,
       res as never,
       next,

--- a/server/src/healthz.spec.ts
+++ b/server/src/healthz.spec.ts
@@ -1,0 +1,54 @@
+import { healthzMiddleware, healthzPayload } from './healthz'
+
+function createResponse() {
+  const headers = new Map<string, string>()
+  return {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers,
+    setHeader(key: string, value: string) {
+      headers.set(key, value)
+      return this
+    },
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(value: unknown) {
+      this.body = value
+      return this
+    },
+  }
+}
+
+describe('healthzMiddleware', () => {
+  it('returns the standard health contract for GET /healthz', () => {
+    const res = createResponse()
+    const next = jest.fn()
+
+    healthzMiddleware(
+      { method: 'GET', path: '/healthz' } as never,
+      res as never,
+      next,
+    )
+
+    expect(next).not.toHaveBeenCalled()
+    expect(res.statusCode).toBe(200)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    expect(res.body).toEqual(healthzPayload)
+  })
+
+  it('passes non-health requests to the next handler', () => {
+    const res = createResponse()
+    const next = jest.fn()
+
+    healthzMiddleware(
+      { method: 'GET', path: '/v1/regions' } as never,
+      res as never,
+      next,
+    )
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(res.statusCode).toBe(0)
+  })
+})

--- a/server/src/healthz.spec.ts
+++ b/server/src/healthz.spec.ts
@@ -8,11 +8,17 @@ jest.mock('./system-database', () => ({
   },
 }))
 
-import {
-  healthzMiddleware,
-  healthzPayload,
-  healthzUnhealthyPayload,
-} from './healthz'
+import { healthzMiddleware, healthzPayload } from './healthz'
+
+const ENV_KEYS = [
+  'DATABASE_URL',
+  'JWT_SECRET',
+  'DEFAULT_REGION_RUNTIME_DOMAIN',
+  'DEFAULT_REGION_TLS_ENABLED',
+  'DEFAULT_REGION_TLS_WILDCARD_CERTIFICATE_SECRET_NAME',
+] as const
+
+type EnvKey = (typeof ENV_KEYS)[number]
 
 function createResponse() {
   const headers = new Map<string, string>()
@@ -35,9 +41,48 @@ function createResponse() {
   }
 }
 
+function captureEnv() {
+  return Object.fromEntries(
+    ENV_KEYS.map((key) => [key, process.env[key]]),
+  ) as Record<EnvKey, string | undefined>
+}
+
+function restoreEnv(snapshot: Record<EnvKey, string | undefined>) {
+  for (const key of ENV_KEYS) {
+    const value = snapshot[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function setHealthzEnv(overrides: Partial<Record<EnvKey, string>>) {
+  const defaults: Record<EnvKey, string> = {
+    DATABASE_URL: 'mongodb://127.0.0.1:27017/sealaf',
+    JWT_SECRET: 'secret',
+    DEFAULT_REGION_RUNTIME_DOMAIN: 'sealaf.example.com',
+    DEFAULT_REGION_TLS_ENABLED: 'false',
+    DEFAULT_REGION_TLS_WILDCARD_CERTIFICATE_SECRET_NAME: 'wildcard-cert',
+  }
+
+  for (const key of ENV_KEYS) {
+    process.env[key] = overrides[key] ?? defaults[key]
+  }
+}
+
 describe('healthzMiddleware', () => {
+  let envSnapshot: Record<EnvKey, string | undefined>
+
   beforeEach(() => {
+    envSnapshot = captureEnv()
+    setHealthzEnv({})
     mockCommand.mockReset()
+  })
+
+  afterEach(() => {
+    restoreEnv(envSnapshot)
   })
 
   it('returns the standard health contract for GET /healthz', async () => {
@@ -58,6 +103,62 @@ describe('healthzMiddleware', () => {
     expect(res.body).toEqual(healthzPayload)
   })
 
+  it('returns missing required config when a necessary value is absent', async () => {
+    delete process.env.JWT_SECRET
+    mockCommand.mockResolvedValueOnce(undefined)
+    const res = createResponse()
+    const next = jest.fn()
+
+    await healthzMiddleware(
+      { method: 'GET', path: '/healthz' } as never,
+      res as never,
+      next,
+    )
+
+    expect(next).not.toHaveBeenCalled()
+    expect(mockCommand).toHaveBeenCalledWith({ ping: 1 })
+    expect(res.statusCode).toBe(503)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    expect(res.body).toMatchObject({
+      service: 'sealaf',
+      status: 'error',
+      issues: [
+        {
+          key: 'JWT_SECRET',
+          message: 'missing required config',
+        },
+      ],
+    })
+  })
+
+  it('returns a config issue when TLS is enabled without a wildcard secret', async () => {
+    process.env.DEFAULT_REGION_TLS_ENABLED = 'true'
+    delete process.env.DEFAULT_REGION_TLS_WILDCARD_CERTIFICATE_SECRET_NAME
+    mockCommand.mockResolvedValueOnce(undefined)
+    const res = createResponse()
+    const next = jest.fn()
+
+    await healthzMiddleware(
+      { method: 'GET', path: '/healthz' } as never,
+      res as never,
+      next,
+    )
+
+    expect(next).not.toHaveBeenCalled()
+    expect(mockCommand).toHaveBeenCalledWith({ ping: 1 })
+    expect(res.statusCode).toBe(503)
+    expect(res.body).toMatchObject({
+      service: 'sealaf',
+      status: 'error',
+      issues: [
+        {
+          key: 'DEFAULT_REGION_TLS_WILDCARD_CERTIFICATE_SECRET_NAME',
+          message: 'required when DEFAULT_REGION_TLS_ENABLED=true',
+        },
+      ],
+    })
+  })
+
   it('returns an error payload when the database ping fails', async () => {
     mockCommand.mockRejectedValueOnce(new Error('db down'))
     const res = createResponse()
@@ -72,8 +173,16 @@ describe('healthzMiddleware', () => {
     expect(next).not.toHaveBeenCalled()
     expect(mockCommand).toHaveBeenCalledWith({ ping: 1 })
     expect(res.statusCode).toBe(503)
-    expect(res.headers.get('Cache-Control')).toBe('no-store')
-    expect(res.body).toEqual(healthzUnhealthyPayload)
+    expect(res.body).toMatchObject({
+      service: 'sealaf',
+      status: 'error',
+      issues: [
+        {
+          key: 'DATABASE_PING',
+          message: 'system database is unreachable',
+        },
+      ],
+    })
   })
 
   it('passes non-health requests to the next handler', async () => {

--- a/server/src/healthz.ts
+++ b/server/src/healthz.ts
@@ -1,11 +1,50 @@
 import { NextFunction, Request, Response } from 'express'
+import { SystemDatabase } from './system-database'
 
 export const healthzPayload = {
   service: 'sealaf',
   status: 'ok',
 } as const
 
-export function healthzMiddleware(
+export const healthzUnhealthyPayload = {
+  service: 'sealaf',
+  status: 'error',
+} as const
+
+const HEALTHZ_TIMEOUT_MS = 900
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number) {
+  let timer: NodeJS.Timeout | undefined
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`healthz timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+  })
+
+  return Promise.race([
+    promise.finally(() => {
+      if (timer) {
+        clearTimeout(timer)
+      }
+    }),
+    timeout,
+  ])
+}
+
+async function checkHealthz() {
+  await withTimeout(SystemDatabase.db.command({ ping: 1 }), HEALTHZ_TIMEOUT_MS)
+}
+
+function respondHealthz(
+  res: Response,
+  statusCode: number,
+  payload: typeof healthzPayload | typeof healthzUnhealthyPayload,
+) {
+  res.setHeader('Cache-Control', 'no-store')
+  return res.status(statusCode).json(payload)
+}
+
+export async function healthzMiddleware(
   req: Request,
   res: Response,
   next: NextFunction,
@@ -14,6 +53,10 @@ export function healthzMiddleware(
     return next()
   }
 
-  res.setHeader('Cache-Control', 'no-store')
-  return res.status(200).json(healthzPayload)
+  try {
+    await checkHealthz()
+    return respondHealthz(res, 200, healthzPayload)
+  } catch {
+    return respondHealthz(res, 503, healthzUnhealthyPayload)
+  }
 }

--- a/server/src/healthz.ts
+++ b/server/src/healthz.ts
@@ -1,0 +1,19 @@
+import { NextFunction, Request, Response } from 'express'
+
+export const healthzPayload = {
+  service: 'sealaf',
+  status: 'ok',
+} as const
+
+export function healthzMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (req.method !== 'GET' || req.path !== '/healthz') {
+    return next()
+  }
+
+  res.setHeader('Cache-Control', 'no-store')
+  return res.status(200).json(healthzPayload)
+}

--- a/server/src/healthz.ts
+++ b/server/src/healthz.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
+import { ServerConfig } from './constants'
 import { SystemDatabase } from './system-database'
 
 export const healthzPayload = {
@@ -6,10 +7,16 @@ export const healthzPayload = {
   status: 'ok',
 } as const
 
-export const healthzUnhealthyPayload = {
-  service: 'sealaf',
-  status: 'error',
-} as const
+type HealthzIssue = {
+  key: string
+  message: string
+}
+
+type HealthzResponse = {
+  service: 'sealaf'
+  status: 'ok' | 'error'
+  issues?: HealthzIssue[]
+}
 
 const HEALTHZ_TIMEOUT_MS = 900
 
@@ -31,17 +38,84 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number) {
   ])
 }
 
-async function checkHealthz() {
-  await withTimeout(SystemDatabase.db.command({ ping: 1 }), HEALTHZ_TIMEOUT_MS)
+function readRequiredConfig(
+  key: string,
+  getter: () => string | undefined,
+  issues: HealthzIssue[],
+) {
+  try {
+    const value = getter()
+    if (!value || !value.trim()) {
+      issues.push({ key, message: 'missing required config' })
+    }
+  } catch {
+    issues.push({ key, message: 'missing required config' })
+  }
 }
 
-function respondHealthz(
-  res: Response,
-  statusCode: number,
-  payload: typeof healthzPayload | typeof healthzUnhealthyPayload,
-) {
+function collectConfigIssues() {
+  const issues: HealthzIssue[] = []
+
+  readRequiredConfig('DATABASE_URL', () => ServerConfig.DATABASE_URL, issues)
+  readRequiredConfig('JWT_SECRET', () => ServerConfig.JWT_SECRET, issues)
+  readRequiredConfig(
+    'DEFAULT_REGION_RUNTIME_DOMAIN',
+    () => ServerConfig.DEFAULT_REGION_RUNTIME_DOMAIN,
+    issues,
+  )
+
+  const rawTlsEnabled = process.env.DEFAULT_REGION_TLS_ENABLED
+  if (
+    rawTlsEnabled !== undefined &&
+    rawTlsEnabled !== 'true' &&
+    rawTlsEnabled !== 'false'
+  ) {
+    issues.push({
+      key: 'DEFAULT_REGION_TLS_ENABLED',
+      message: 'must be true or false',
+    })
+  }
+
+  if (
+    ServerConfig.DEFAULT_REGION_TLS_ENABLED &&
+    !ServerConfig.DEFAULT_REGION_TLS_WILDCARD_CERTIFICATE_SECRET_NAME?.trim()
+  ) {
+    issues.push({
+      key: 'DEFAULT_REGION_TLS_WILDCARD_CERTIFICATE_SECRET_NAME',
+      message: 'required when DEFAULT_REGION_TLS_ENABLED=true',
+    })
+  }
+
+  return issues
+}
+
+async function collectHealthzIssues() {
+  const issues = collectConfigIssues()
+
+  try {
+    await withTimeout(SystemDatabase.db.command({ ping: 1 }), HEALTHZ_TIMEOUT_MS)
+  } catch {
+    issues.push({
+      key: 'DATABASE_PING',
+      message: 'system database is unreachable',
+    })
+  }
+
+  return issues
+}
+
+function respondHealthz(res: Response, issues: HealthzIssue[]) {
   res.setHeader('Cache-Control', 'no-store')
-  return res.status(statusCode).json(payload)
+  const payload: HealthzResponse =
+    issues.length === 0
+      ? healthzPayload
+      : {
+          service: 'sealaf',
+          status: 'error',
+          issues,
+        }
+
+  return res.status(issues.length === 0 ? 200 : 503).json(payload)
 }
 
 export async function healthzMiddleware(
@@ -53,10 +127,6 @@ export async function healthzMiddleware(
     return next()
   }
 
-  try {
-    await checkHealthz()
-    return respondHealthz(res, 200, healthzPayload)
-  } catch {
-    return respondHealthz(res, 503, healthzUnhealthyPayload)
-  }
+  const issues = await collectHealthzIssues()
+  return respondHealthz(res, issues)
 }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -8,6 +8,7 @@ import { InitializerService } from './initializer/initializer.service'
 import { SystemDatabase } from './system-database'
 import * as helmet from 'helmet'
 import * as bodyParser from 'body-parser'
+import { healthzMiddleware } from './healthz'
 
 async function bootstrap() {
   await SystemDatabase.ready
@@ -16,6 +17,7 @@ async function bootstrap() {
     logger: ['error', 'warn', 'log', 'debug', 'verbose'],
   })
 
+  app.use(healthzMiddleware)
   app.enableCors()
 
   app.useGlobalPipes(

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -25,6 +25,12 @@ server {
         try_files $uri =404;
     }
 
+    location = /healthz {
+        default_type application/json;
+        add_header Cache-Control "no-store" always;
+        return 200 '{"service":"sealaf","status":"ok"}\n';
+    }
+
     # assume that everything else is handled by the application router, by injecting the index.html.
     location / {
         autoindex off;


### PR DESCRIPTION
## Summary
- Add a server-side `/healthz` middleware that returns `{"service":"sealaf","status":"ok"}` with `Cache-Control: no-store` before the NestJS business pipeline.
- Add the same `/healthz` contract to the web nginx entrypoint.
- Move web and server startup, liveness, and readiness probes to `/healthz`.
- Document the stable health check contract in the deployment guide.

## Verification
- `npm test -- healthz.spec.ts` in `server/`
- `npm run build` in `server/`
- `npm run tsc` in `web/`
- `npm run build` in `web/`
- `helm lint deploy/charts/sealaf`
- `helm template sealaf deploy/charts/sealaf | rg -n "startupProbe|livenessProbe|readinessProbe|path: /healthz|path: /v1/regions"`
- `git diff --check`
