### PR TITLE
feat(ingress): allow configured iframe parent origins

### DIFF
--- a/.github/workflows/build-scripts-updated.yml
+++ b/.github/workflows/build-scripts-updated.yml
@@ -31,7 +31,9 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Test deployment scripts and Helm chart
-        run: bash deploy/tests/mongodb-secret-resolution.sh
+        run: |
+          bash deploy/tests/mongodb-secret-resolution.sh
+          bash deploy/tests/ingress-embedded-origins.sh
 
       - name: Log workflow completion
         run: |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -293,6 +293,20 @@ mongodb://<username>:<password>@<endpoint>/<database>?authSource=admin&replicaSe
 | `SERVER_JWT_SECRET` | 自动复用或生成 | 指定 server JWT secret。未设置时优先复用 `sealaf-config.SERVER_JWT_SECRET`。 |
 | `STRICT_SECRET_REUSE` | `true` | 已有 Helm release 但找不到旧 JWT Secret 时，是否拒绝生成新值。 |
 
+### iframe 嵌入配置
+
+在 `VALUES_FILE`（或其他 Helm values 覆盖文件）中配置允许的 iframe 父页面精确 origin：
+
+```yaml
+ingress:
+  # 允许作为 iframe 父页面的精确 origin，包含协议和可选端口。
+  embeddedAllowedOrigins:
+    - http://province.example.com:8080
+    - https://province.example.com
+```
+
+列表项必须包含 `http://` 或 `https://` 协议，且只能包含主机名和可选端口；不支持通配符、通配域名或 URL path。配置会追加到 Web Ingress 的 `frame-ancestors`，不会改变 Ingress host/path、`cloudDomain`、SSO 或 CORS。
+
 ### MongoDB 参数
 
 | 参数 | 默认值 | 说明 |

--- a/deploy/charts/sealaf/templates/_helpers.tpl
+++ b/deploy/charts/sealaf/templates/_helpers.tpl
@@ -105,7 +105,17 @@ app.kubernetes.io/name: {{ include "sealaf.serverName" . }}
 
 {{- define "sealaf.contentSecurityPolicy" -}}
 {{- $domain := include "sealaf.domainWithPort" . -}}
-{{- printf "default-src * blob: data: *.%s %s; img-src * data: blob: resource: *.%s %s; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.%s %s resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.%s %s resource: *.baidu.com *.bdstatic.com; frame-src 'self' *.%s %s mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://%s https://*.%s" $domain $domain $domain $domain $domain $domain $domain $domain $domain $domain $domain $domain -}}
+{{- $embeddedAllowedOrigins := join " " .Values.ingress.embeddedAllowedOrigins -}}
+{{- range $origin := .Values.ingress.embeddedAllowedOrigins -}}
+{{- if not (and (kindIs "string" $origin) (regexMatch "^https?://([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)*[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?::[0-9]{1,5})?$" $origin)) -}}
+{{- fail (printf "ingress.embeddedAllowedOrigins contains invalid exact origin %q; use http:// or https:// with a hostname and optional port only" $origin) -}}
+{{- end -}}
+{{- end -}}
+{{- $embeddedAllowedOriginsSuffix := "" -}}
+{{- if $embeddedAllowedOrigins -}}
+{{- $embeddedAllowedOriginsSuffix = printf " %s" $embeddedAllowedOrigins -}}
+{{- end -}}
+{{- printf "default-src * blob: data: *.%s %s; img-src * data: blob: resource: *.%s %s; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.%s %s resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.%s %s resource: *.baidu.com *.bdstatic.com; frame-src 'self' *.%s %s mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://%s https://*.%s%s" $domain $domain $domain $domain $domain $domain $domain $domain $domain $domain $domain $domain $embeddedAllowedOriginsSuffix -}}
 {{- end }}
 
 {{- define "sealaf.mongodbRootSecretName" -}}

--- a/deploy/charts/sealaf/values.yaml
+++ b/deploy/charts/sealaf/values.yaml
@@ -230,6 +230,8 @@ mongodb:
 ingress:
   enabled: true
   className: nginx
+  # 允许作为 iframe 父页面的精确 origin，包含协议和可选端口。
+  embeddedAllowedOrigins: []
   tls:
     enabled: true
   extraAnnotations: {}

--- a/deploy/tests/ingress-embedded-origins.sh
+++ b/deploy/tests/ingress-embedded-origins.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="${TEST_DIR}/../charts/sealaf"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local content=$1
+  local expected=$2
+  local message=$3
+
+  grep -Fq -- "${expected}" <<< "${content}" || fail "${message}: missing '${expected}'"
+}
+
+assert_not_contains() {
+  local content=$1
+  local unexpected=$2
+  local message=$3
+
+  if grep -Fq -- "${unexpected}" <<< "${content}"; then
+    fail "${message}: found '${unexpected}'"
+  fi
+}
+
+expected_csp() {
+  local embedded_origin=${1:-}
+  local suffix=""
+
+  if [ -n "${embedded_origin}" ]; then
+    suffix=" ${embedded_origin}"
+  fi
+
+  printf "%s" "default-src * blob: data: *.127.0.0.1.nip.io 127.0.0.1.nip.io; img-src * data: blob: resource: *.127.0.0.1.nip.io 127.0.0.1.nip.io; connect-src * wss: blob: resource:; style-src 'self' 'unsafe-inline' blob: *.127.0.0.1.nip.io 127.0.0.1.nip.io resource:; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: *.127.0.0.1.nip.io 127.0.0.1.nip.io resource: *.baidu.com *.bdstatic.com; frame-src 'self' *.127.0.0.1.nip.io 127.0.0.1.nip.io mailto: tel: weixin: mtt: *.baidu.com; frame-ancestors 'self' https://127.0.0.1.nip.io https://*.127.0.0.1.nip.io${suffix}"
+}
+
+assert_response_headers() {
+  local rendered=$1
+  local embedded_origin=${2:-}
+  local csp
+
+  csp="$(expected_csp "${embedded_origin}")"
+  assert_contains "${rendered}" 'more_clear_headers "X-Frame-Options:";' "NGINX clears X-Frame-Options"
+  assert_contains "${rendered}" 'higress.io/response-header-control-remove: X-Frame-Options' "Higress removes X-Frame-Options"
+  assert_not_contains "${rendered}" 'more_set_headers "X-Frame-Options:' "NGINX does not set X-Frame-Options"
+  assert_contains "${rendered}" "more_set_headers \"Content-Security-Policy: ${csp}\";" "NGINX retains and updates CSP"
+  assert_contains "${rendered}" "Content-Security-Policy \"${csp}\"" "Higress retains and updates CSP"
+}
+
+assert_invalid_origin_rejected() {
+  local origin=$1
+
+  if helm template sealaf "${CHART_DIR}" --set-string "ingress.embeddedAllowedOrigins[0]=${origin}" >/dev/null 2>&1; then
+    fail "invalid embedded origin was accepted: ${origin}"
+  fi
+}
+
+helm lint "${CHART_DIR}" >/dev/null
+
+default_rendered="$(helm template sealaf "${CHART_DIR}")"
+assert_response_headers "${default_rendered}"
+
+http_origin="http://province.example.com:8080"
+http_rendered="$(helm template sealaf "${CHART_DIR}" --set-string "ingress.embeddedAllowedOrigins[0]=${http_origin}")"
+assert_response_headers "${http_rendered}" "${http_origin}"
+
+https_origin="https://province.example.com"
+https_rendered="$(helm template sealaf "${CHART_DIR}" --set-string "ingress.embeddedAllowedOrigins[0]=${https_origin}")"
+assert_response_headers "${https_rendered}" "${https_origin}"
+
+assert_invalid_origin_rejected '*'
+assert_invalid_origin_rejected 'https://*.example.com'
+assert_invalid_origin_rejected 'https://province.example.com/path'
+assert_invalid_origin_rejected 'province.example.com'
+
+echo "Embedded Ingress origin rendering tests passed"


### PR DESCRIPTION
## Summary

Add `ingress.embeddedAllowedOrigins` for exact HTTP/HTTPS iframe parent origins while preserving the existing Content-Security-Policy and synchronizing NGINX and Higress response-header controls. Add Helm rendering coverage for the default, HTTP, HTTPS, and invalid-origin cases.

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Chart as Helm Chart
    participant Ingress as Web Ingress
    participant Parent as Parent Page
    Chart->>Ingress: Render existing CSP plus configured frame-ancestors origins
    Chart->>Ingress: Remove X-Frame-Options for NGINX and Higress
    Parent->>Ingress: Load Sealaf in an iframe
    Ingress-->>Parent: Allow only origins listed by frame-ancestors
```

## Verification

- `helm lint deploy/charts/sealaf`
- `bash deploy/tests/ingress-embedded-origins.sh`
- `git diff origin/main... --check`

The existing MongoDB test remains incompatible with macOS Bash 3 because it uses associative arrays; it is unrelated to this change.
